### PR TITLE
lge: Update Workaround

### DIFF
--- a/arch/arm/mach-msm/include/mach/board.h
+++ b/arch/arm/mach-msm/include/mach/board.h
@@ -414,7 +414,7 @@ struct msm_panel_common_pdata {
 	char cont_splash_enabled;
 	char mdp_iommu_split_domain;
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	u32 splash_screen_addr;
 	u32 splash_screen_size;
 	u32 avtimer_phy;

--- a/arch/arm/mach-msm/lge/Kconfig
+++ b/arch/arm/mach-msm/lge/Kconfig
@@ -131,3 +131,12 @@ config MACH_LGE_NO_STOCK_INFO
 	help
 	 LG Stock DEBUG INFO
 
+config MACH_LGE_2ND_GEN_KK_WORKAROUD
+	depends on MACH_LGE
+	bool "MSM7x25A V3 errors Workaround"
+	default n
+	help
+	 Disable support for "Copy splash image to kernel memory" and KeyLED.
+	 The 2nd gen devices not have this support in bootloader.
+	 And KeyLED make screen On forever.
+

--- a/arch/arm/mach-msm/lge/vee3/Kconfig
+++ b/arch/arm/mach-msm/lge/vee3/Kconfig
@@ -14,14 +14,6 @@ config MACH_MSM7X25A_V3_DS
     help
         Support for the LG Electronics MSM7x25A V3 DualSim.
 
-config MACH_MSM7X25A_V3_KK_WORKAROUD
-    depends on MACH_MSM7X25A_V3
-    bool "MSM7x25A V3 errors Workaround"
-    default n
-    help
-        Disable support for "Copy splash image to kernel memory".
-        Used to fix fb0 error in vee3 devices and disable keyled.
-
 config LGE_BATTERY_SUSPEND_RESUME
     depends on ARCH_MSM7X27A
     select MACH_LGE

--- a/drivers/video/backlight/rt9396_bl.c
+++ b/drivers/video/backlight/rt9396_bl.c
@@ -63,11 +63,8 @@
 #define RT9396BL_REG_CURRENT		0x47	/* Register address to control Backlight Level */
 #define RT9396BL_REG_LED_ON		0x83	/* Register address for LED1 ~ LED4 on seting */
 #define RT9396BL_REG_LED_OFF		0x80	/* Register address for LED1 ~ LED4 off seting */
-// [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
 #define RT9396BL_REG_KEYLED_ON		0x93	/* Register address for LED5 ~ LED6 on seting */
 #define RT9396BL_REG_KEYLED_OFF		0x90	/* Register address for LED5 ~ LED6 off seting */
-#endif
 
 //LDO ON
 #define RT9396BL_REG_LDO1_ON	0x23	/* Register address for LDO 1 voltage setting */
@@ -87,13 +84,10 @@
 #define RT9396BL_VAL_LDO4	0x04	/* value for LDO 4 voltage setting */
 #define RT9396BL_VAL_LED_SET	0x34
 
-// [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
 #ifdef CONFIG_LEDS_LP5521
 #define RT9396BL_VAL_KEYLED_SET	0x05	// 2.34mA
 #else
 #define RT9396BL_VAL_KEYLED_SET	0x04	//1.95mA
-#endif
 #endif
 
 #define LEDS_BACKLIGHT_NAME		"lcd-backlight"
@@ -169,7 +163,9 @@ static int rt9396_powerstate = POWERON_STATE;
 static struct rt9396_ctrl_tbl rt9396bl_inital_tbl[] = {
 	{ RT9396BL_REG_LED_ON, RT9396BL_VAL_LED_SET },
 // [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifdef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
+	{ RT9396BL_REG_KEYLED_OFF, 0x00 },
+#else
 	{ RT9396BL_REG_KEYLED_ON, RT9396BL_VAL_KEYLED_SET },
 #endif
 	{ 0xFF, 0xFE }
@@ -178,10 +174,7 @@ static struct rt9396_ctrl_tbl rt9396bl_inital_tbl[] = {
 /* Set to sleep mode  */
 static struct rt9396_ctrl_tbl rt9396bl_sleep_tbl[] = {
 	{ RT9396BL_REG_LED_OFF, 0x00 },
-// [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
 	{ RT9396BL_REG_KEYLED_OFF, 0x00 },
-#endif
 	{ 0xFF, 0xFE }
 };
 static int bl_chargerlogo = 0;
@@ -476,7 +469,7 @@ static int rt9396_send_intensity(struct rt9396_driver_data *drvdata, int next)
 int rt9396_send_intensity_button(struct rt9396_driver_data *drvdata, int level)
 {
 // [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	if(level)
 	{
 	printk("[%s] key-backlight ON ! \n", __func__);
@@ -724,8 +717,6 @@ static struct led_classdev rt9396_led_dev = {
 	.brightness_set = leds_brightness_set,
 };
 
-// [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
 static void button_leds_brightness_set(struct led_classdev *led_cdev, enum led_brightness value)
 {
 	struct rt9396_driver_data *drvdata = dev_get_drvdata(led_cdev->dev->parent);
@@ -742,7 +733,6 @@ static struct led_classdev rt9396_keyled_dev = {
 	.brightness_set = button_leds_brightness_set,
 	.brightness		= LED_OFF,
 };
-#endif
 
 static int rt9396_probe(struct i2c_client *i2c_dev, const struct i2c_device_id *i2c_dev_id)
 {
@@ -809,13 +799,11 @@ static int rt9396_probe(struct i2c_client *i2c_dev, const struct i2c_device_id *
 		err = device_create_file(drvdata->led->dev, &dev_attr_drvstat);
 		err = device_create_file(drvdata->led->dev, &dev_attr_chargerlogo);
 	}
-// [Caio99BR][caiooliveirafarias0@gmail.com] Workaround for bug of screen still awake after lock
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+
 	if (led_classdev_register(&i2c_dev->dev, &rt9396_keyled_dev) == 0) {
 		eprintk("Registering led class dev successfully.\n");
 		drvdata->led = &rt9396_keyled_dev;
 	}
-#endif
 
 	i2c_set_clientdata(i2c_dev, drvdata);
 	i2c_set_adapdata(i2c_dev->adapter, i2c_dev);

--- a/drivers/video/msm/mdp.c
+++ b/drivers/video/msm/mdp.c
@@ -2613,7 +2613,7 @@ static int mdp_probe(struct platform_device *pdev)
 #endif
         static int contSplash_update_done;
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	void *splash_virt_addr;
 	int cur_page;
 	unsigned long cur_addr;
@@ -2658,7 +2658,7 @@ static int mdp_probe(struct platform_device *pdev)
 			mdp4_hw_init();
 #else
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 		mdp_hw_init(mdp_pdata->cont_splash_enabled);
 #else
 		mdp_hw_init();
@@ -2702,7 +2702,7 @@ static int mdp_probe(struct platform_device *pdev)
         if (mdp_pdata) {
 		if (mdp_pdata->cont_splash_enabled) {
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 			uint32 bpp = 3;
 			mdp_pipe_ctrl(MDP_CMD_BLOCK, MDP_BLOCK_POWER_ON, FALSE);
 			/*read panel wxh and calculate splash screen
@@ -2789,7 +2789,7 @@ static int mdp_probe(struct platform_device *pdev)
 		mfd->ov1_wb_buf->size = mdp_pdata->ov1_wb_size;
 		mfd->mem_hid = mdp_pdata->mem_hid;
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 		mfd->avtimer_phy = mdp_pdata->avtimer_phy;
 #endif
 	} else {
@@ -2797,7 +2797,7 @@ static int mdp_probe(struct platform_device *pdev)
 		mfd->ov1_wb_buf->size = 0;
 		mfd->mem_hid = 0;
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 		mfd->avtimer_phy = 0;
 #endif
 	}
@@ -3223,7 +3223,7 @@ void mdp_footswitch_ctrl(boolean on)
 }
 
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 void mdp_free_splash_buffer(struct msm_fb_data_type *mfd)
 {
 	if (mfd->copy_splash_buf) {

--- a/drivers/video/msm/mdp.h
+++ b/drivers/video/msm/mdp.h
@@ -77,7 +77,7 @@ extern uint32 mdp_intr_mask;
 #define MDP_ALLOC(x)  kmalloc(x, GFP_KERNEL)
 
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 struct splash_pages {
 	struct page **pages;
 	int nrpages;
@@ -752,7 +752,7 @@ extern struct mdp_hist_mgmt *mdp_hist_mgmt_array[];
 #define MDP_DMA_P_LUT_POST    BIT(4)
 
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 void mdp_hw_init(int splash);
 #else
 void mdp_hw_init(void);
@@ -802,7 +802,7 @@ int mdp_lcdc_on(struct platform_device *pdev);
 int mdp_lcdc_off(struct platform_device *pdev);
 void mdp_lcdc_update(struct msm_fb_data_type *mfd);
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 void mdp_free_splash_buffer(struct msm_fb_data_type *mfd);
 #endif
 #ifdef CONFIG_FB_MSM_MDP303

--- a/drivers/video/msm/mdp_hw_init.c
+++ b/drivers/video/msm/mdp_hw_init.c
@@ -585,7 +585,7 @@ static void mdp_load_lut_param(void)
 #define   IRQ_EN_1__MDP_IRQ___M    0x00000800
 
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 void mdp_hw_init(int splash)
 #else
 void mdp_hw_init(void)
@@ -638,7 +638,7 @@ void mdp_hw_init(void)
 
 #ifndef CONFIG_FB_MSM_MDP22
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	if (!splash)
 		MDP_OUTP(MDP_BASE + 0xE0000, 0);
 #endif

--- a/drivers/video/msm/msm_fb.c
+++ b/drivers/video/msm/msm_fb.c
@@ -2149,7 +2149,7 @@ static int msm_fb_pan_display_sub(struct fb_var_screeninfo *var,
 				backlight_duration);
 
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	if (info->node == 0 && (mfd->cont_splash_done)) /* primary */
 		mdp_free_splash_buffer(mfd);
 #endif

--- a/drivers/video/msm/msm_fb.h
+++ b/drivers/video/msm/msm_fb.h
@@ -196,7 +196,7 @@ struct msm_fb_data_type {
 	bool writeback_active_cnt;
 	int cont_splash_done;
 //[Caio99BR][caiooliveirafarias0@gmail.com] Workaround for broken fb0 with splash_screen
-#ifndef CONFIG_MACH_MSM7X25A_V3_KK_WORKAROUD
+#ifndef CONFIG_MACH_LGE_2ND_GEN_KK_WORKAROUD
 	void *copy_splash_buf;
 	unsigned char *copy_splash_phys;
 #endif


### PR DESCRIPTION
All 2nd Gen devices need this option enabled, because not have bootloader support.

Signed-off-by: Caio Oliveira caiooliveirafarias0@gmail.com
